### PR TITLE
change standard to double-quote not single-quote

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,10 @@ Style/FrozenStringLiteralComment:
 
 Metrics/LineLength:
   Max: 85
+  
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  ConsistentQuotesInMultiline: true
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes


### PR DESCRIPTION
This updates rubocop.yml file so that double quotes are now the enforced standard instead of single quotes.