### PR TITLE
Order subtotal

### DIFF
--- a/db/migrate/20170224194105_add_subtotal_to_order_donations.rb
+++ b/db/migrate/20170224194105_add_subtotal_to_order_donations.rb
@@ -1,5 +1,5 @@
 class AddSubtotalToOrderDonations < ActiveRecord::Migration[5.0]
   def change
-    add_column :order_donations, :subtotal, :integer
+    add_column :order_donations, :subtotal, :float
   end
 end

--- a/db/migrate/20170224194105_add_subtotal_to_order_donations.rb
+++ b/db/migrate/20170224194105_add_subtotal_to_order_donations.rb
@@ -1,0 +1,5 @@
+class AddSubtotalToOrderDonations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :order_donations, :subtotal, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170224005005) do
+ActiveRecord::Schema.define(version: 20170224194105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20170224005005) do
     t.integer  "quantity"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.float    "subtotal"
     t.index ["donation_id"], name: "index_order_donations_on_donation_id", using: :btree
     t.index ["order_id"], name: "index_order_donations_on_order_id", using: :btree
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,6 +45,6 @@ end
   n = rand(1..5)
   Donation.pluck(:id).sample(n).each do |d|
     q = rand(1..10)
-    o.details.create(donation_id: d, quantity: q)
+    o.details.create(donation_id: d, quantity: q, subtotal: Donation.find(d).price * q)
   end
 end


### PR DESCRIPTION
Hey guys,

This adds a migration (with updated seed) to add a subtotal column on the OrderDonation table. This allows us calculate the subtotal only once when the order is created instead of every time we needed it. It also allows us to use an active record method instead of a ruby enumerable to get the order total.

-Ashley